### PR TITLE
UDP Client: Support writing large reports

### DIFF
--- a/tests/unit/Jaeger/UDPClientTest.php
+++ b/tests/unit/Jaeger/UDPClientTest.php
@@ -93,7 +93,7 @@ class UDPClientTest extends TestCase
             $resource,
             Argument::type('string'),
             Argument::type('int'),
-            0,
+            512,
             '1.1.1.1',
             1234
         )->willReturn(123)->shouldBeCalledTimes(1);


### PR DESCRIPTION
If a report is larger than 65536 bytes it will be rejected by kernel and PHP engine and never sent. With this, we ensure that the packet is always sent and that it has proper signaling (MSG_EOR or MSG_EOF). 

TLDR; Solves the following issue:

```PHP Warning:  socket_sendto(): unable to write to socket [90]: Message too long```