### PR TITLE
Test enhancement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,11 @@ jobs:
     docker:
       - image: circleci/php:7.2-node
 
+  php73:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:7.3-node
+
   integration:
     docker:
       - image: circleci/php:7.2-node
@@ -68,4 +73,5 @@ workflows:
       - php70
       - php71
       - php72
+      - php73
       - integration

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,13 @@
         "ext-sockets": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.0 || ^6.5",
         "squizlabs/php_codesniffer": "2.*",
         "guzzlehttp/guzzle": "~6.0"
+    },
+    "suggest": {
+        "ext-gmp": "It can handle the large numbers",
+        "ext-bcmath": "It can handle large integer numbers"
     },
     "license": "Apache-2.0",
     "authors": [
@@ -24,6 +28,12 @@
     "autoload": {
         "psr-4": {
             "OpenCensus\\Trace\\Exporter\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "OpenCensus\\Tests\\Unit\\Trace\\Exporter\\": "tests/unit/",
+            "OpenCensus\\Tests\\Integration\\Trace\\Exporter\\": "tests/integration/"
         }
     },
     "scripts": {

--- a/tests/unit/Jaeger/SpanConverterBcmathTest.php
+++ b/tests/unit/Jaeger/SpanConverterBcmathTest.php
@@ -17,8 +17,6 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Exporter\Jaeger;
 
-require_once __DIR__ . '/SpanConverterTest.php';
-
 use OpenCensus\Tests\Unit\Trace\Exporter\Jaeger\SpanConverterTest;
 
 use OpenCensus\Trace\Exporter\Jaeger\HexdecConverterBcMath;

--- a/tests/unit/Jaeger/UDPClientTest.php
+++ b/tests/unit/Jaeger/UDPClientTest.php
@@ -17,8 +17,6 @@
 
 namespace OpenCensus\Trace\Exporter\Jaeger;
 
-require_once 'src/Thrift/Types.php';
-
 use Jaeger\Thrift\Batch;
 use Jaeger\Thrift\Process;
 use Jaeger\Thrift\Span;

--- a/tests/unit/JaegerExporterBcmathTest.php
+++ b/tests/unit/JaegerExporterBcmathTest.php
@@ -17,8 +17,6 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
-require_once __DIR__ . '/JaegerExporterTest.php';
-
 use OpenCensus\Tests\Unit\Trace\Exporter\JaegerExporterTest;
 
 use OpenCensus\Trace\Exporter\JaegerExporter;

--- a/tests/unit/JaegerExporterTest.php
+++ b/tests/unit/JaegerExporterTest.php
@@ -17,8 +17,6 @@
 
 namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
-require_once 'src/Thrift/Agent.php';
-
 use OpenCensus\Trace\Exporter\JaegerExporter;
 use OpenCensus\Trace\Annotation;
 use OpenCensus\Trace\MessageEvent;


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test in Circleci build because the `php-7.3` version is stable release now.
- Add the different released PHPUnit versions to support multiple PHP versions.
- Add the `autoload-dev` block in `composer.json` and define the class namespaces in `tests` to load these classes automatically.
- Remove useless `require_once` code because the classes will be loaded automatically via `autoload.php`.
- The successful Circle CI build result is available [here](https://circleci.com/workflow-run/531fda62-e03f-46b2-a20a-9b3b8e5266a8).
- Add the `suggest` block in `composer.json` to recommend the `gmp` and `bcmath` extensions.
It's related to issue #11.