### PR TITLE
Add GMP to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Trace data to a Jaeger instance using Thrift (Compact Protocol) over UDP.
 
 * PHP >= 5.6
 * 64-bit version of PHP
+* PHP [GMP](https://secure.php.net/manual/en/intro.gmp.php) extension
 
 ## Installation & basic usage
 


### PR DESCRIPTION
It bit me when I deployed my application on staging, and I saw my logs polluted with entries like:
`NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function OpenCensus\Trace\Exporter\Jaeger\gmp_add() in /dls/vendor/opencensus/opencensus-exporter-jaeger/src/Jaeger/HexdecConverter.php:43`

It's better to have it visible in the README.md.

Solves #11 