### PR TITLE
Composer, apache/thrift keep lib/php only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,10 @@
         }
     },
     "scripts": {
-        "post-dependencies-solving": "OpenCensus\\Trace\\Exporter\\Installer::checkPhpExtDependency"
+        "post-dependencies-solving": "OpenCensus\\Trace\\Exporter\\Installer::checkPhpExtDependency",
+        "post-install-cmd": [
+            "cd vendor/apache/thrift && ls | grep -v lib | xargs rm -rf",
+            "cd vendor/apache/thrift/lib && ls | grep -v php | xargs rm -rf"
+        ]
     }
 }


### PR DESCRIPTION
This PR aims to reduce disk usage.
[apache/thrift](https://github.com/apache/thrift) comes with the whole C++ implementation of the software, plus with libraries for ~25 programming languages.

By removing the unnecessary files and folders, we end up with 560K of dependencies instead of 19MB.

This issue becomes more of a concern to projects that commit the `vendor/` directory.

### master
```
9:25:07 ➜  opencensus-php-exporter-jaeger git:(master)  rm -rf vendor
9:25:12 ➜  opencensus-php-exporter-jaeger git:(master)  composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
### more composer output here
Generating autoload files
9:25:19 ➜  opencensus-php-exporter-jaeger git:(master)  du -hs vendor/apache/thrift
 19M	vendor/apache/thrift
```

### composer-thrift-keep-php-lib-only
```
9:25:34 ➜  opencensus-php-exporter-jaeger git:(composer-thrift-keep-php-lib-only)  rm -rf vendor
9:25:38 ➜  opencensus-php-exporter-jaeger git:(composer-thrift-keep-php-lib-only)  composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
### more composer output here
> cd vendor/apache/thrift && ls | grep -v lib | xargs rm -rf
/tmp/opencensus-php-exporter-jaeger/vendor/apache/thrift
> cd vendor/apache/thrift/lib && ls | grep -v php | xargs rm -rf
/tmp/opencensus-php-exporter-jaeger/vendor/apache/thrift/lib
9:25:46 ➜  opencensus-php-exporter-jaeger git:(composer-thrift-keep-php-lib-only)  du -hs vendor/apache/thrift
560K	vendor/apache/thrift
```